### PR TITLE
drop redundant headers

### DIFF
--- a/src/luarapidxml.cpp
+++ b/src/luarapidxml.cpp
@@ -1,7 +1,4 @@
-#include <cmath>
 #include <cstring>
-#include <fstream>
-#include <iostream>
 #include <stdexcept>
 #include <sstream>
 


### PR DESCRIPTION
Usage of "iostram" creates "ios_base" that internally works with
locales. In case of static build it leads to quite unexpected
results:

```
0  0x00007ffff6e818df in raise () from /lib64/libc.so.6
1  0x00007ffff6e6bcf5 in abort () from /lib64/libc.so.6
2  0x00007ffff6ec4c17 in __libc_message () from /lib64/libc.so.6
3  0x00007ffff6ecb53c in malloc_printerr () from /lib64/libc.so.6
4  0x00007ffff6eccc64 in _int_free () from /lib64/libc.so.6
5  0x00007fffe349fa02 in std::locale::_Impl::_M_install_facet(std::locale::id const*, std::locale::facet const*) () from /home/oleg/Projects/tdg/.rocks/lib/tarantool/luarapidxml.so
6  0x00007fffe348c323 in std::locale::_Impl::_Impl(unsigned long) () from /home/oleg/Projects/tdg/.rocks/lib/tarantool/luarapidxml.so
7  0x00007fffe348d295 in std::locale::_S_initialize_once() () from /home/oleg/Projects/tdg/.rocks/lib/tarantool/luarapidxml.so
8  0x00007ffff759ee57 in __pthread_once_slow () from /lib64/libpthread.so.0
9  0x00007fffe348d2e1 in std::locale::_S_initialize() () from /home/oleg/Projects/tdg/.rocks/lib/tarantool/luarapidxml.so
10 0x00007fffe348d323 in std::locale::locale() () from /home/oleg/Projects/tdg/.rocks/lib/tarantool/luarapidxml.so
11 0x00007fffe34ba26c in std::ios_base::Init::Init() () from /home/oleg/Projects/tdg/.rocks/lib/tarantool/luarapidxml.so
12 0x00007fffe34865a0 in __static_initialization_and_destruction_0 (__initialize_p=1, __priority=65535) at /usr/include/c++/4.8.2/iostream:74
13 _GLOBAL__sub_I_luarapidxml.cpp(void) () at /tmp/luarocks_luarapidxml-2.0.0-1-z1oSgY/luarapidxml/src/luarapidxml.cpp:380
14 0x00007ffff7de3d0a in call_init.part () from /lib64/ld-linux-x86-64.so.2
15 0x00007ffff7de3e0a in _dl_init () from /lib64/ld-linux-x86-64.so.2
16 0x00007ffff7de7def in dl_open_worker () from /lib64/ld-linux-x86-64.so.2
17 0x00007ffff6f82ab7 in _dl_catch_exception () from /lib64/libc.so.6
18 0x00007ffff7de765e in _dl_open () from /lib64/ld-linux-x86-64.so.2
19 0x00007ffff7bd11ba in dlopen_doit () from /lib64/libdl.so.2
20 0x00007ffff6f82ab7 in _dl_catch_exception () from /lib64/libc.so.6
21 0x00007ffff6f82b53 in _dl_catch_error () from /lib64/libc.so.6
22 0x00007ffff7bd1939 in _dlerror_run () from /lib64/libdl.so.2
23 0x00007ffff7bd125a in dlopen@@GLIBC_2.2.5 () from /lib64/libdl.so.2
24 0x000000000075059a in ll_loadfunc ()
25 0x000000000075096b in lj_cf_package_loadlib ()
26 0x0000000000756a47 in lj_BC_FUNCC ()
27 0x000000000074fe7f in lj_cf_package_require ()
28 0x0000000000756a47 in lj_BC_FUNCC ()
29 0x0000000000739ad6 in lua_pcall ()
30 0x00000000006e4053 in luaT_call (L=0x4076dd90, nargs=<optimized out>, nreturns=<optimized out>) at /__w/sdk/sdk/tarantool-2.5/src/lua/utils.c:1022
31 0x00000000006ddec6 in lua_fiber_run_f (ap=<error reading variable: value has been optimized out>) at /__w/sdk/sdk/tarantool-2.5/src/lua/fiber.c:450
32 0x000000000056d63c in fiber_cxx_invoke(fiber_func, typedef __va_list_tag __va_list_tag *) (f=<optimized out>, ap=<optimized out>) at /__w/sdk/sdk/tarantool-2.5/src/lib/core/fiber.h:870
33 0x0000000000700b70 in fiber_loop (data=<optimized out>) at /__w/sdk/sdk/tarantool-2.5/src/lib/core/fiber.c:879
34 0x0000000000d165ef in coro_init () at /__w/sdk/sdk/tarantool-2.5/third_party/coro/coro.c:110
```

This patch removes some unused headers and prevents locale
modification. After the patch no crashes are observed.