### PR TITLE
drop "sstream" dependency

### DIFF
--- a/src/luarapidxml.cpp
+++ b/src/luarapidxml.cpp
@@ -273,7 +273,7 @@ static int encode_element(
             const char* key = lua_tolstring(L, -2, &key_len);
 
             str.push_back(' ');
-            str.append( key, key_len);
+            str.append(key, key_len);
             str.append("=\"", 2);
             encode_string(L, str, lua_gettop(L));
             str.push_back('\"');
@@ -331,8 +331,7 @@ static int encode_element(
         // -2: tag
     }
 
-    str.push_back('<');
-    str.push_back('/');
+    str.append("</", 2);
     str.append(tag, tag_len);
     str.push_back('>');
     return 0;


### PR DESCRIPTION
This patch is a follow-up to f93c49318f8f4a98279e61e238d284ac34c585c3.
Actually problem happens when luarapidxml works with
luagraphqlparser rocks that are compiled on centos:7 but run on
centos:8.

Stracktrace is following:
```
Thread 1 "tarantool" received signal SIGABRT, Aborted.
0x00007f91c18398df in raise () from /lib64/libc.so.6
0x00007f91c18398df in raise () from /lib64/libc.so.6
0x00007f91c1823cf5 in abort () from /lib64/libc.so.6
0x00007f91c187cc17 in __libc_message () from /lib64/libc.so.6
0x00007f91c188353c in malloc_printerr () from /lib64/libc.so.6
0x00007f91c1884c64 in _int_free () from /lib64/libc.so.6
0x00007f91be30a762 in std::locale::_Impl::_M_install_facet(std::locale::id const*, std::locale::facet const*) () from /home/oleg/Projects/tdg/.rocks/lib/tarantool/luarapidxml.so
0x00007f91be2f7083 in std::locale::_Impl::_Impl(unsigned long) () from /home/oleg/Projects/tdg/.rocks/lib/tarantool/luarapidxml.so
0x00007f91be2f7ff5 in std::locale::_S_initialize_once() () from /home/oleg/Projects/tdg/.rocks/lib/tarantool/luarapidxml.so
0x00007f91c1f56e57 in __pthread_once_slow () from /lib64/libpthread.so.0
0x00007f91be2f8041 in std::locale::_S_initialize() () from /home/oleg/Projects/tdg/.rocks/lib/tarantool/luarapidxml.so
0x00007f91be2f8083 in std::locale::locale() () from /home/oleg/Projects/tdg/.rocks/lib/tarantool/luarapidxml.so
0x00007f91be2f31f5 in std::basic_ios<char, std::char_traits<char> >::basic_ios (this=0x7f91ad9ffd88) at /usr/include/c++/4.8.2/bits/basic_ios.h:456
std::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >::basic_ostringstream (__mode=std::_S_out, this=0x7f91ad9ffd30, __in_chrg=<optimized out>, __vtt_parm=<optimized out>)
    at /usr/include/c++/4.8.2/sstream:424
encode (L=0x4032c350) at /tmp/luarocks_luarapidxml-2.0.1-1-1qoSlO/luarapidxml/src/luarapidxml.cpp:349
0x0000000000756c87 in lj_BC_FUNCC ()
0x0000000000739d16 in lua_pcall ()
0x00000000006e3ea3 in luaT_call (L=0x4032c350, nargs=<optimized out>, nreturns=<optimized out>) at /__w/sdk/sdk/tarantool-2.5/src/lua/utils.c:1022
0x00000000006ddd16 in lua_fiber_run_f (ap=<error reading variable: value has been optimized out>) at /__w/sdk/sdk/tarantool-2.5/src/lua/fiber.c:450
0x000000000056c63c in fiber_cxx_invoke(fiber_func, typedef __va_list_tag __va_list_tag *) (f=<optimized out>, ap=<optimized out>) at /__w/sdk/sdk/tarantool-2.5/src/lib/core/fiber.h:870
0x0000000000700a70 in fiber_loop (data=<optimized out>) at /__w/sdk/sdk/tarantool-2.5/src/lib/core/fiber.c:879
0x0000000000d1539f in coro_init () at /__w/sdk/sdk/tarantool-2.5/third_party/coro/coro.c:110
```

Instead of usage c++ string stream this patch uses simple string that doesn't use locales.
So seems performance is better than before.

Before patch:
```
Test transcoding performance
    FIXTURE 'ebay'
    size: 34.73 KiB
    decode: 13668.86 Req/s
    encode: 13846.42 Req/s
    FIXTURE 'reed'
    size: 277.01 KiB
    decode: 320.63 Req/s
    encode: 496.39 Req/s
    FIXTURE 'customer'
    size: 503.57 KiB
    decode: 201.87 Req/s
    encode: 311.01 Req/s
    Bandwidth (decode average): 216.50 MiB/s
    Bandwidth (encode average): 252.22 MiB/s
```

After patch:
```
Test transcoding performance
    FIXTURE 'ebay'
    size: 34.73 KiB
    decode: 13565.20 Req/s
    encode: 15434.85 Req/s
    FIXTURE 'reed'
    size: 277.01 KiB
    decode: 294.18 Req/s
    encode: 597.02 Req/s
    FIXTURE 'customer'
    size: 503.57 KiB
    decode: 198.93 Req/s
    encode: 395.51 Req/s
    Bandwidth (decode average): 212.45 MiB/s
    Bandwidth (encode average): 293.12 MiB/s
```